### PR TITLE
get rid of getChildren arrow function

### DIFF
--- a/elements/Svg.js
+++ b/elements/Svg.js
@@ -32,7 +32,7 @@ class Svg extends Component{
         this.id = id;
     }
 
-    getChildren = () => {
+    getChildren = function(){
         return Children.map(this.props.children, child => {
             return cloneElement(child, {
                 svgId: this.id


### PR DESCRIPTION
this doesn't work the same in arrow functions - I getting this.props = undefined