### PR TITLE
Switches RNSVGPath.m and RNSVGText.m strokeDash to new strokeDasharray

### DIFF
--- a/ios/RNSVGPath.m
+++ b/ios/RNSVGPath.m
@@ -57,7 +57,7 @@
         CGContextSetLineWidth(context, self.strokeWidth);
         CGContextSetLineCap(context, self.strokeLinecap);
         CGContextSetLineJoin(context, self.strokeLinejoin);
-        RNSVGCGFloatArray dash = self.strokeDash;
+        RNSVGCGFloatArray dash = self.strokeDasharray;
         
         if (dash.count) {
             CGContextSetLineDash(context, self.strokeDashoffset, dash.array, dash.count);

--- a/ios/RNSVGText.m
+++ b/ios/RNSVGText.m
@@ -83,7 +83,7 @@ static void RNSVGFreeTextFrame(RNSVGTextFrame frame)
         CGContextSetLineWidth(context, self.strokeWidth);
         CGContextSetLineCap(context, self.strokeLinecap);
         CGContextSetLineJoin(context, self.strokeLinejoin);
-        RNSVGCGFloatArray dash = self.strokeDash;
+        RNSVGCGFloatArray dash = self.strokeDasharray;
         
         if (dash.count) {
             CGContextSetLineDash(context, self.strokeDashoffset, dash.array, dash.count);


### PR DESCRIPTION
A few iOS files weren't switched over to the new `strokeDasharray`