### PR TITLE
Remove the postinstall script that runs rnpm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
         "svgpath": "^2.1.5",
         "lodash": "^4.0.0"
     },
-    "scripts": {
-        "postinstall": "rnpm link react-native-svg"
-    },
     "nativePackage": true,
     "rnpm": {
         "ios": {


### PR DESCRIPTION
In our build scripts, `rnpm` does not 100% accurately insert packages properly. The combination of other dependencies confuses `rnpm` which ultimately causes conflicts and build errors. This is the case for our application, but I suspect it also applies to some other people as well.

This PR is just to remove the postinstall script so the developer can install manually, or via running rnpm themselves.